### PR TITLE
Support minimatch at filters' key

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "index.d.ts"
   ],
   "scripts": {
-    "test:cov": "npm run build && jest test/** --coverage && npm run lint",
+    "test:cov": "jest test/** --coverage && npm run lint",
     "test": "npm run lint && jest",
     "lint": "xo src/**",
     "prepublish": "npm run build",

--- a/src/alphax.ts
+++ b/src/alphax.ts
@@ -12,7 +12,7 @@ export type Middleware = (file: File, meta: any) => any
 export type Glob = string[] | string
 export type TransformFn = (contents: string, file: File) => Promise<string> | string
 export type Task = (app: AlphaX) => Promise<void> | void
-export type Filter = (filepath: string) => string
+export type Filter = (filepath: string) => boolean
 export type Renamer = (filepath: string) => string
 
 export interface Files {
@@ -166,8 +166,12 @@ export class AlphaX extends EventEmitter {
 
     const transform = curryFileTransformer((file: File) => this.transformFile(file))
 
-    const filter = curryFileTransformer((file: File) =>
-      this.filters.some(_filter => !_filter(file.relative)) ? null : true)
+    const filter = curryFileTransformer((file: File) => {
+      if (file.isDirectory() || this.filters.some(_filter => !_filter(file.relative))) {
+        return null
+      }
+      return true
+    })
 
     const collect = curryFileTransformer((file: File) => {
       const { relative } = file

--- a/src/alphax.ts
+++ b/src/alphax.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { EventEmitter } from 'events'
 import * as es from 'event-stream'
 import * as File from 'vinyl'
+import match from 'minimatch'
 import ware from 'ware'
 import { src, dest, SrcOptions } from 'vinyl-fs'
 import { isArray, isFunction, isPromise, curryFileTransformer, isBuffer, getRenamerByConfig } from './utils'
@@ -135,10 +136,15 @@ export class AlphaX extends EventEmitter {
     this.use(getRenameMiddleware(this.renamers, this.renameChangelog))
 
     if (this.filtersConfig) {
-      Object.keys(this.filtersConfig).forEach(fileName => {
-        if (!this.filtersConfig[fileName]) {
-          this.patterns.push('!' + path.join(this.baseDir, fileName))
+      this.filters.push((filepath: string) => {
+        for (const glob of Object.keys(this.filtersConfig)) {
+          if (match(filepath, glob, { dot: true })) {
+            if (!this.filtersConfig[glob]) {
+              return null
+            }
+          }
         }
+        return true
       })
     }
 

--- a/test/__snapshots__/alphax.test.ts.snap
+++ b/test/__snapshots__/alphax.test.ts.snap
@@ -4,8 +4,6 @@ exports[`alphax base 1`] = `
 Object {
   "index.ts": " ==== source name is index.js
 ",
-  "lib2": null,
-  "lib2/core": null,
   "lib2/core/core.ts": " ==== source name is core.js
 ",
   "lib2/lib2.ts": " ==== source name is lib.js
@@ -17,8 +15,6 @@ exports[`alphax cwd 1`] = `
 Object {
   "index.ts": " ==== source name is index.js
 ",
-  "lib2": null,
-  "lib2/core": null,
   "lib2/core/core.ts": " ==== source name is core.js
 ",
   "lib2/lib2.ts": " ==== source name is lib.js
@@ -30,13 +26,10 @@ exports[`alphax filter function - 1 1`] = `
 Object {
   "index.js": "index.js: index.js
 ",
-  "lib": null,
-  "lib/core": null,
   "lib/core/core.js": "lib/core/core.js: core.js
 ",
   "lib/lib.js": "lib/lib.js: lib.js
 ",
-  "lib/util": null,
   "lib/util/util.js": "lib/util/util.js: util.js
 ",
 }
@@ -44,7 +37,6 @@ Object {
 
 exports[`alphax filter function - 2 1`] = `
 Object {
-  "style": null,
   "style/index.css": "style/index.css: index.css
 ",
 }
@@ -52,18 +44,14 @@ Object {
 
 exports[`alphax rename function 1`] = `
 Object {
-  "lib": null,
-  "lib/core": null,
   "lib/core/core.js": "lib/core/core.js: core.js
 ",
   "lib/lib.js": "lib/lib.js: lib.js
 ",
-  "lib/utils": null,
   "lib/utils/util.js": "lib/utils/util.js: util.js
 ",
   "main.js": "main.js: index.js
 ",
-  "style": null,
   "style/index.css": "style/index.css: index.css
 ",
 }


### PR DESCRIPTION
Use `minimatch` to support glob pattern at filter's key:

```js
filters: {
          'lib': true,
          'lib/util/**': false,
          'style/**': false,
          'index.js': true
}
```

Another change is that now the empty directory will not be generated.